### PR TITLE
Fix error when parsing .gyp file with a backslash

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,6 +179,8 @@ function parseString(input, at) {
   let value = '';
   while (input[at] !== type) {
     if (input[at] === '\\') {
+      const cr = String.fromCodePoint(0x0D);
+      const lf = String.fromCodePoint(0x0A);
       switch (input[++at]) {
         case '"':
         case "'":
@@ -208,7 +210,18 @@ function parseString(input, at) {
           value += String.fromCodePoint(parseInt(hexString, 16));
           at += 2;
           break;
-        } default:
+        }
+        case cr:
+          if (input[at + 1] === lf) {
+            at += 2;
+          } else {
+            at++;
+          }
+          break;
+        case lf:
+          at++;
+          break;
+        default:
           return [ new ParseError(input, at, 'Unknown escape character') ];
       }
     } else {

--- a/index.js
+++ b/index.js
@@ -176,8 +176,6 @@ function parseString(input, at) {
   if (input[at] !== '"' && input[at] !== "'")
     return [ new ParseError(input, at, 'Expected \' or "') ];
   const type = input[at++];
-  const cr = String.fromCodePoint(0x0D);
-  const lf = String.fromCodePoint(0x0A);
   let value = '';
   while (input[at] !== type) {
     if (input[at] === '\\') {
@@ -211,14 +209,14 @@ function parseString(input, at) {
           at += 2;
           break;
         }
-        case cr:
-          if (input[at + 1] === lf) {
+        case '\r':
+          if (input[at + 1] === '\n') {
             at += 2;
           } else {
             at++;
           }
           break;
-        case lf:
+        case '\n':
           at++;
           break;
         default:

--- a/index.js
+++ b/index.js
@@ -176,11 +176,11 @@ function parseString(input, at) {
   if (input[at] !== '"' && input[at] !== "'")
     return [ new ParseError(input, at, 'Expected \' or "') ];
   const type = input[at++];
+  const cr = String.fromCodePoint(0x0D);
+  const lf = String.fromCodePoint(0x0A);
   let value = '';
   while (input[at] !== type) {
     if (input[at] === '\\') {
-      const cr = String.fromCodePoint(0x0D);
-      const lf = String.fromCodePoint(0x0A);
       switch (input[++at]) {
         case '"':
         case "'":

--- a/test/multiline_cr.in
+++ b/test/multiline_cr.in
@@ -1,0 +1,1 @@
+{  'foo': ['bar '          'baz'],  'qux \quux': 'corge',}

--- a/test/multiline_cr.out
+++ b/test/multiline_cr.out
@@ -1,0 +1,1 @@
+{  "foo": ["bar baz"],  "qux quux": "corge"}

--- a/test/multiline_crlf.in
+++ b/test/multiline_crlf.in
@@ -1,0 +1,6 @@
+{
+  'foo': ['bar '
+          'baz'],
+  'qux \
+quux': 'corge',
+}

--- a/test/multiline_crlf.out
+++ b/test/multiline_crlf.out
@@ -1,0 +1,4 @@
+{
+  "foo": ["bar baz"],
+  "qux quux": "corge"
+}

--- a/test/multiline_lf.in
+++ b/test/multiline_lf.in
@@ -1,0 +1,6 @@
+{
+  'foo': ['bar '
+          'baz'],
+  'qux \
+quux': 'corge',
+}

--- a/test/multiline_lf.out
+++ b/test/multiline_lf.out
@@ -1,0 +1,4 @@
+{
+  "foo": ["bar baz"],
+  "qux quux": "corge"
+}


### PR DESCRIPTION
Regarding [Unify node.gyp code styling · Issue #41072 · nodejs/node](https://github.com/nodejs/node/issues/41072), in `node.gyp`, multi-line character strings are combined by inserting `\` before a line break.
That causes 'Unknown escape character' error in `gyp-parser`.

This PR is a bug fix on the `gyp-parser` side.